### PR TITLE
use `loadManifest` on exhibition pages

### DIFF
--- a/apps/static-site/src/app/[locale]/exhibitions/[exhibition]/page.tsx
+++ b/apps/static-site/src/app/[locale]/exhibitions/[exhibition]/page.tsx
@@ -5,6 +5,7 @@ import { ManifestLoader } from "@/app/provider";
 import imageServiceLinks from "@repo/iiif/build/meta/image-service-links.json";
 import allExhibitions from "@repo/iiif/build/collections/exhibitions/collection.json";
 import { SlotContext } from "@/blocks/slot-context";
+import { loadManifest } from "@/iiif";
 
 export const generateStaticParams = async () => {
   const exhibitions = [];
@@ -25,8 +26,7 @@ export const generateStaticParams = async () => {
 export default async function Exhibition({ params }: { params: { exhibition: string; locale: string } }) {
   unstable_setRequestLocale(params.locale);
   const manifestSlug = `manifests/${params.exhibition}`;
-  const meta = await import(`@repo/iiif/build/manifests/${params.exhibition}/meta.json`);
-  const manifest = await import(`@repo/iiif/build/manifests/${params.exhibition}/manifest.json`);
+  const { manifest, meta } = await loadManifest(manifestSlug);
   const viewObjectLinks = imageServiceLinks[manifestSlug as keyof typeof imageServiceLinks] || [];
 
   return (


### PR DESCRIPTION
Now consistent with how the manifest is loaded on the 'manifest' page https://github.com/digirati-co-uk/heritage.tudelft.nl/blob/main/apps/static-site/src/app/%5Blocale%5D/objects/%5Bmanifest%5D/page.tsx#L13

