### PR TITLE
MDX files for metadata for all pages without manifests

### DIFF
--- a/apps/iiif/.iiifrc-base.yml
+++ b/apps/iiif/.iiifrc-base.yml
@@ -9,12 +9,17 @@ run:
   - extract-slug-source
   - delft-extract-labels
   - extract-part-of-collection
-  - extract-thumbnail
+  - extract-thumbnail-local
   - manifest-sqlite
   - metadata-analysis
   - site-collections
   - delft-image-source
   - typesense-manifests
+
+config:
+  extract-thumbnail-local:
+    width: 1080
+    height: 1080
 
 stores:
   collective-access:

--- a/apps/iiif/scripts/extract-thumbnail-local.js
+++ b/apps/iiif/scripts/extract-thumbnail-local.js
@@ -1,0 +1,56 @@
+import { createThumbnailHelper } from "@iiif/helpers";
+import { extract } from "iiif-hss";
+
+extract({
+  id: "extract-thumbnail-local",
+  name: "Extract Thumbnail",
+  types: ["Manifest"],
+  invalidate: async (resource, api, config) => {
+    const cache = await api.caches.value;
+    return !cache.extractThumbnail && cache.extractThumbnail !== false;
+  }},
+  async (resource, api, config) => {
+    const vault = resource.vault;
+    const helper = createThumbnailHelper(vault);
+    const thumbnail = await helper.getBestThumbnailAtSize(
+      api.resource,
+      config.width
+        ? {
+            width: config.width,
+            height: config.height || config.width,
+          }
+        : {
+            width: 256,
+            height: 256,
+          },
+      config.dereference || false
+    );
+
+    if (thumbnail?.best) {
+      return {
+        meta: { thumbnail: thumbnail.best },
+        caches: { extractThumbnail: true },
+      };
+    }
+    else {
+      const thumbnail = await helper.getBestThumbnailAtSize(
+        api.resource, {
+              width: 256,
+              height: 256,
+            },
+        config.dereference || false
+      );
+
+      if (thumbnail?.best) {
+        return {
+          meta: { thumbnail: thumbnail.best },
+          caches: { extractThumbnail: true },
+        };
+      }
+    }
+
+    return {
+      caches: { extractThumbnail: false },
+    };
+  },
+)

--- a/apps/static-site/content/pages/en/collections-listing.mdx
+++ b/apps/static-site/content/pages/en/collections-listing.mdx
@@ -1,0 +1,4 @@
+---
+title: Collections
+path: "/collections"
+---

--- a/apps/static-site/content/pages/en/exhibitions-listing.mdx
+++ b/apps/static-site/content/pages/en/exhibitions-listing.mdx
@@ -1,0 +1,4 @@
+---
+title: Exhibitions
+path: "/exhibitions"
+---

--- a/apps/static-site/content/pages/en/home.mdx
+++ b/apps/static-site/content/pages/en/home.mdx
@@ -2,7 +2,7 @@
 title: Academic Heritage, History and Art
 description: Explore the history of Delft University of Technology and the Special Collections of TU Delft Library
 image: "https://dlc.services/thumbs/7/13/00a1a6c3-25cb-4873-b570-2a77205852c9/full/683,1024/0/default.jpg"
-imageWidth: 800
-imageHeight: 800
+imageWidth: 683
+imageHeight: 1024
 path: "/"
 ---

--- a/apps/static-site/content/pages/en/home.mdx
+++ b/apps/static-site/content/pages/en/home.mdx
@@ -1,4 +1,8 @@
 ---
 title: Academic Heritage, History and Art
+description: Explore the history of Delft University of Technology and the Special Collections of TU Delft Library
+image: "https://dlc.services/thumbs/7/13/00a1a6c3-25cb-4873-b570-2a77205852c9/full/683,1024/0/default.jpg"
+imageWidth: 800
+imageHeight: 800
 path: "/"
 ---

--- a/apps/static-site/content/pages/en/home.mdx
+++ b/apps/static-site/content/pages/en/home.mdx
@@ -1,0 +1,4 @@
+---
+title: Academic Heritage, History and Art
+path: "/"
+---

--- a/apps/static-site/content/pages/en/publications-listing.mdx
+++ b/apps/static-site/content/pages/en/publications-listing.mdx
@@ -1,0 +1,4 @@
+---
+title: Publications
+path: "/publications"
+---

--- a/apps/static-site/content/pages/en/search.mdx
+++ b/apps/static-site/content/pages/en/search.mdx
@@ -1,0 +1,4 @@
+---
+title: Search
+path: "/search"
+---

--- a/apps/static-site/content/pages/nl/collections-listing.mdx
+++ b/apps/static-site/content/pages/nl/collections-listing.mdx
@@ -1,0 +1,4 @@
+---
+title: Collecties
+path: "/collections"
+---

--- a/apps/static-site/content/pages/nl/exhibitions-listing.mdx
+++ b/apps/static-site/content/pages/nl/exhibitions-listing.mdx
@@ -1,0 +1,4 @@
+---
+title: Tentoonstellingen
+path: "/exhibitions"
+---

--- a/apps/static-site/content/pages/nl/home.mdx
+++ b/apps/static-site/content/pages/nl/home.mdx
@@ -3,6 +3,6 @@ title: Academisch Erfgoed, Geschiedenis en Kunst
 description: Verken de geschiedenis van de TU Delft en de bijzondere collecties van de TU Delft Library
 image: "https://dlc.services/thumbs/7/13/00a1a6c3-25cb-4873-b570-2a77205852c9/full/683,1024/0/default.jpg"
 path: "/"
-imageWidth: 800
-imageHeight: 800
+imageWidth: 683
+imageHeight: 1024
 ---

--- a/apps/static-site/content/pages/nl/home.mdx
+++ b/apps/static-site/content/pages/nl/home.mdx
@@ -1,4 +1,8 @@
 ---
 title: Academisch Erfgoed, Geschiedenis en Kunst
+description: Verken de geschiedenis van de TU Delft en de bijzondere collecties van de TU Delft Library
+image: "https://dlc.services/thumbs/7/13/00a1a6c3-25cb-4873-b570-2a77205852c9/full/683,1024/0/default.jpg"
 path: "/"
+imageWidth: 800
+imageHeight: 800
 ---

--- a/apps/static-site/content/pages/nl/home.mdx
+++ b/apps/static-site/content/pages/nl/home.mdx
@@ -1,0 +1,4 @@
+---
+title: Academisch Erfgoed, Geschiedenis en Kunst
+path: "/"
+---

--- a/apps/static-site/content/pages/nl/publications-listing.mdx
+++ b/apps/static-site/content/pages/nl/publications-listing.mdx
@@ -1,0 +1,4 @@
+---
+title: Publicaties
+path: "/publications"
+---

--- a/apps/static-site/content/pages/nl/search.mdx
+++ b/apps/static-site/content/pages/nl/search.mdx
@@ -1,0 +1,4 @@
+---
+title: Zoek
+path: "/search"
+---

--- a/apps/static-site/content/publications/en/delta-spanish-flu.mdx
+++ b/apps/static-site/content/publications/en/delta-spanish-flu.mdx
@@ -1,9 +1,8 @@
 ---
 date: "2020-07-20"
-title: "The Spanish Flu in Delft test"
+title: "The Spanish Flu in Delft"
 author: "Abel Streefland"
 image: https://dlc.services/thumbs/7/21/b65dbfcc-4daf-0b7d-86fc-74a126248b03/full/full/0/default.jpg
-description: "Spanish Flu description test"
 ---
 
 _TU Delft has closed before because of a pandemic_

--- a/apps/static-site/contentlayer.config.ts
+++ b/apps/static-site/contentlayer.config.ts
@@ -12,12 +12,14 @@ const Pages = defineDocumentType(() => ({
     path: { type: "string", required: true },
     description: { type: "string", required: false },
     image: { type: "string", required: false },
+    imageWidth: { type: "number", required: false },
+    imageHeight: { type: "number", required: false },
   },
   computedFields: {
     lang: {
       type: "string",
-      resolve: (publication) => {
-        return publication._id.split("/")[1];
+      resolve: (page) => {
+        return page._id.split("/")[1];
       },
     },
   },
@@ -33,6 +35,8 @@ const Publication = defineDocumentType(() => ({
     date: { type: "string", required: false },
     author: { type: "string", required: false },
     image: { type: "string", required: false },
+    imageWidth: { type: "number", required: false },
+    imageHeight: { type: "number", required: false },
     hero: { type: "string", required: false },
     toc: { type: "boolean", default: false },
     depth: { type: "number", default: 3 },

--- a/apps/static-site/contentlayer.config.ts
+++ b/apps/static-site/contentlayer.config.ts
@@ -11,6 +11,7 @@ const Pages = defineDocumentType(() => ({
     title: { type: "string", required: true },
     path: { type: "string", required: true },
     description: { type: "string", required: false },
+    image: { type: "string", required: false },
   },
   computedFields: {
     lang: {

--- a/apps/static-site/src/app/[locale]/about/page.tsx
+++ b/apps/static-site/src/app/[locale]/about/page.tsx
@@ -1,4 +1,3 @@
-import { allPages } from ".contentlayer/generated";
 import { Slot } from "@/blocks/slot";
 import { SlotContext } from "@/blocks/slot-context";
 import { Page } from "@/components/Page";
@@ -6,35 +5,28 @@ import { Illustration } from "@/components/blocks/Illustration";
 import { useMDXComponent } from "next-contentlayer/hooks";
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
-import { getSiteName, getBasicMetadata, makeTitle } from "@/helpers/metadata";
-
-function getAboutPage({ params }: { params: { locale: string } }) {
-  const aboutPages = allPages.filter((page) => page.path === "/about");
-  const aboutPage = aboutPages.find((page) => page.lang === params.locale) || aboutPages[0];
-  if (!aboutPage) throw new Error(`No about page found for locale ${params.locale}`);
-  return aboutPage;
-}
+import { getSiteName, getBasicMetadata, makeTitle, getMdx } from "@/helpers/metadata";
 
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
   const t = await getTranslations();
   const siteName = await getSiteName();
-  const aboutPage = getAboutPage({ params: params });
-  const aboutTitle = aboutPage.title || t("About");
-  const title = makeTitle([aboutTitle, siteName]);
-  const description = aboutPage.description || t("aboutDesc");
-  return getBasicMetadata(params.locale, siteName, title, description);
+  const page = getMdx({ params: { pageName: "About", path: "/about", locale: params.locale } });
+  const title = makeTitle([page.title || t("About"), siteName]);
+  const description = page.description || t("defaultDesc");
+  const image = page.image;
+  return getBasicMetadata(params.locale, siteName, title, description, image);
 }
 
 export default async function AboutPage({ params }: { params: { locale: string } }) {
-  const aboutPage = getAboutPage({ params: params });
-  const MDXContent = useMDXComponent(aboutPage.body.code);
+  const page = getMdx({ params: { pageName: "About", path: "/about", locale: params.locale } });
+  const MDXContent = useMDXComponent(page.body.code);
   const CustomSlot = (inner: any) => {
     return <Slot context={{ page: "about", locale: params.locale }} {...inner} />;
   };
 
   return (
     <Page>
-      <h1 className="text-4xl font-medium">{aboutPage.title}</h1>
+      <h1 className="text-4xl font-medium">{page.title}</h1>
       <div className="mb-32 mt-8 h-full lg:col-span-2">
         <article className="prose md:prose-xl prose-lg max-w-full leading-snug md:leading-snug">
           <SlotContext name="page" value={"about"}>

--- a/apps/static-site/src/app/[locale]/about/page.tsx
+++ b/apps/static-site/src/app/[locale]/about/page.tsx
@@ -10,11 +10,19 @@ import { getSiteName, getBasicMetadata, makeTitle, getMdx } from "@/helpers/meta
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
   const t = await getTranslations();
   const siteName = await getSiteName();
-  const page = getMdx({ params: { pageName: "About", path: "/about", locale: params.locale } });
+  const path = "/about";
+  const page = getMdx({ params: { pageName: "About", path: path, locale: params.locale } });
   const title = makeTitle([page.title || t("About"), siteName]);
   const description = page.description || t("defaultDesc");
   const image = page.image;
-  return getBasicMetadata(params.locale, siteName, title, description, image);
+  return getBasicMetadata({
+    locale: params.locale,
+    siteName: siteName,
+    title: title,
+    description: description,
+    image: image,
+    path: path,
+  });
 }
 
 export default async function AboutPage({ params }: { params: { locale: string } }) {

--- a/apps/static-site/src/app/[locale]/about/page.tsx
+++ b/apps/static-site/src/app/[locale]/about/page.tsx
@@ -5,19 +5,18 @@ import { Illustration } from "@/components/blocks/Illustration";
 import { useMDXComponent } from "next-contentlayer/hooks";
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
-import { getSiteName, getBasicMetadata, makeTitle, getMdx, getDefaultMetaMdx } from "@/helpers/metadata";
+import { getBasicMetadata, makeTitle, getMdx, getDefaultMetaMdx } from "@/helpers/metadata";
 
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
   const t = await getTranslations();
-  const siteName = await getSiteName();
   const path = "/about";
   const defaultMeta = getDefaultMetaMdx({ params: { locale: params.locale } });
   const page = getMdx({ params: { pageName: "About", path: path, locale: params.locale } });
-  const title = makeTitle([page.title ?? defaultMeta.title, siteName]);
+  const title = makeTitle([page.title, defaultMeta.title]);
   const description = page.description ?? defaultMeta.description;
   return getBasicMetadata({
     locale: params.locale,
-    siteName: siteName,
+    siteName: defaultMeta.title,
     title: title,
     description: description,
     image: {

--- a/apps/static-site/src/app/[locale]/about/page.tsx
+++ b/apps/static-site/src/app/[locale]/about/page.tsx
@@ -5,22 +5,26 @@ import { Illustration } from "@/components/blocks/Illustration";
 import { useMDXComponent } from "next-contentlayer/hooks";
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
-import { getSiteName, getBasicMetadata, makeTitle, getMdx } from "@/helpers/metadata";
+import { getSiteName, getBasicMetadata, makeTitle, getMdx, getDefaultMetaMdx } from "@/helpers/metadata";
 
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
   const t = await getTranslations();
   const siteName = await getSiteName();
   const path = "/about";
+  const defaultMeta = getDefaultMetaMdx({ params: { locale: params.locale } });
   const page = getMdx({ params: { pageName: "About", path: path, locale: params.locale } });
-  const title = makeTitle([page.title || t("About"), siteName]);
-  const description = page.description || t("defaultDesc");
-  const image = page.image;
+  const title = makeTitle([page.title ?? defaultMeta.title, siteName]);
+  const description = page.description ?? defaultMeta.description;
   return getBasicMetadata({
     locale: params.locale,
     siteName: siteName,
     title: title,
     description: description,
-    image: image,
+    image: {
+      url: page.image ?? defaultMeta.image,
+      width: page.image ? page.imageWidth : defaultMeta.imageWidth,
+      height: page.image ? page.imageHeight : defaultMeta.imageWidth,
+    },
     path: path,
   });
 }

--- a/apps/static-site/src/app/[locale]/collections/[collection]/page.tsx
+++ b/apps/static-site/src/app/[locale]/collections/[collection]/page.tsx
@@ -5,7 +5,7 @@ import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
 // import siteMap from "@repo/iiif/build/meta/sitemap.json";
 import { Metadata } from "next";
 import { getValue } from "@iiif/helpers";
-import { getSiteName, baseURL, defaultImage, makeTitle } from "@/helpers/metadata";
+import { getSiteName, baseURL, makeTitle, getDefaultMetaMdx } from "@/helpers/metadata";
 
 export async function generateMetadata({
   params,
@@ -15,12 +15,16 @@ export async function generateMetadata({
   const t = await getTranslations();
   const slug = `collections/${params.collection}`;
   const { collection } = await loadCollection(slug);
+  const defaultMeta = getDefaultMetaMdx({ params: { locale: params.locale } });
   const siteName = await getSiteName();
-  const collTitle = getValue(collection.label, { language: params.locale, fallbackLanguages: ["nl", "en"] });
-  const description = getValue(collection.summary, { language: params.locale, fallbackLanguages: ["nl", "en"] });
+  const collTitle =
+    getValue(collection.label, { language: params.locale, fallbackLanguages: ["nl", "en"] }) ?? defaultMeta.title;
+  const description =
+    getValue(collection.summary, { language: params.locale, fallbackLanguages: ["nl", "en"] }) ??
+    defaultMeta.description;
   const title = makeTitle([collTitle, siteName]);
   const url = `/collections/${params.collection}`;
-
+  // this page currently uses the default meta image as a 'collection image' is not available.
   return {
     metadataBase: new URL(baseURL),
     description: description,
@@ -33,8 +37,9 @@ export async function generateMetadata({
       url: url,
       images: [
         {
-          url: defaultImage,
-          width: 1080,
+          url: defaultMeta.image ?? "",
+          width: defaultMeta.imageWidth,
+          height: defaultMeta.imageWidth,
         },
       ],
     },

--- a/apps/static-site/src/app/[locale]/collections/[collection]/page.tsx
+++ b/apps/static-site/src/app/[locale]/collections/[collection]/page.tsx
@@ -5,7 +5,7 @@ import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
 // import siteMap from "@repo/iiif/build/meta/sitemap.json";
 import { Metadata } from "next";
 import { getValue } from "@iiif/helpers";
-import { getSiteName, siteURL, fallbackImage, makeTitle } from "@/helpers/metadata";
+import { getSiteName, baseURL, defaultImage, makeTitle } from "@/helpers/metadata";
 
 export async function generateMetadata({
   params,
@@ -19,10 +19,10 @@ export async function generateMetadata({
   const collTitle = getValue(collection.label, { language: params.locale, fallbackLanguages: ["nl", "en"] });
   const description = getValue(collection.summary, { language: params.locale, fallbackLanguages: ["nl", "en"] });
   const title = makeTitle([collTitle, siteName]);
-  const objectURL = `${siteURL}/${params.locale}/objects/${params.collection}`;
+  const url = `/collections/${params.collection}`;
 
   return {
-    metadataBase: new URL(siteURL),
+    metadataBase: new URL(baseURL),
     description: description,
     title: title,
     openGraph: {
@@ -30,10 +30,10 @@ export async function generateMetadata({
       siteName: siteName,
       title: title,
       type: "website",
-      url: objectURL,
+      url: url,
       images: [
         {
-          url: fallbackImage,
+          url: defaultImage,
           width: 1080,
         },
       ],

--- a/apps/static-site/src/app/[locale]/collections/[collection]/page.tsx
+++ b/apps/static-site/src/app/[locale]/collections/[collection]/page.tsx
@@ -5,7 +5,7 @@ import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
 // import siteMap from "@repo/iiif/build/meta/sitemap.json";
 import { Metadata } from "next";
 import { getValue } from "@iiif/helpers";
-import { getSiteName, baseURL, makeTitle, getDefaultMetaMdx } from "@/helpers/metadata";
+import { baseURL, makeTitle, getDefaultMetaMdx } from "@/helpers/metadata";
 
 export async function generateMetadata({
   params,
@@ -16,13 +16,11 @@ export async function generateMetadata({
   const slug = `collections/${params.collection}`;
   const { collection } = await loadCollection(slug);
   const defaultMeta = getDefaultMetaMdx({ params: { locale: params.locale } });
-  const siteName = await getSiteName();
-  const collTitle =
-    getValue(collection.label, { language: params.locale, fallbackLanguages: ["nl", "en"] }) ?? defaultMeta.title;
+  const collTitle = getValue(collection.label, { language: params.locale, fallbackLanguages: ["nl", "en"] });
   const description =
     getValue(collection.summary, { language: params.locale, fallbackLanguages: ["nl", "en"] }) ??
     defaultMeta.description;
-  const title = makeTitle([collTitle, siteName]);
+  const title = makeTitle([collTitle, defaultMeta.title]);
   const url = `/collections/${params.collection}`;
   // this page currently uses the default meta image as a 'collection image' is not available.
   return {
@@ -31,7 +29,7 @@ export async function generateMetadata({
     title: title,
     openGraph: {
       locale: params.locale,
-      siteName: siteName,
+      siteName: defaultMeta.title,
       title: title,
       type: "website",
       url: url,

--- a/apps/static-site/src/app/[locale]/collections/page.tsx
+++ b/apps/static-site/src/app/[locale]/collections/page.tsx
@@ -2,23 +2,27 @@ import { Page } from "@/components/Page";
 import { Slot } from "@/blocks/slot";
 import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
 import { CollectionListing } from "@/components/pages/CollectionListing";
-import { getSiteName, getBasicMetadata, makeTitle, getMdx } from "@/helpers/metadata";
+import { getSiteName, getBasicMetadata, makeTitle, getMdx, getDefaultMetaMdx } from "@/helpers/metadata";
 import { Metadata } from "next";
 
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
   const t = await getTranslations();
   const siteName = await getSiteName();
   const path = "/collections";
+  const defaultMeta = getDefaultMetaMdx({ params: { locale: params.locale } });
   const page = getMdx({ params: { pageName: "Collections", path: path, locale: params.locale } });
-  const title = makeTitle([page.title || t("Collections"), siteName]);
-  const description = page.description || t("defaultDesc");
-  const image = page.image;
+  const title = makeTitle([page.title ?? defaultMeta.title, siteName]);
+  const description = page.description ?? defaultMeta.description;
   return getBasicMetadata({
     locale: params.locale,
     siteName: siteName,
     title: title,
     description: description,
-    image: image,
+    image: {
+      url: page.image ?? defaultMeta.image,
+      width: page.image ? page.imageWidth : defaultMeta.imageWidth,
+      height: page.image ? page.imageHeight : defaultMeta.imageWidth,
+    },
     path: path,
   });
 }

--- a/apps/static-site/src/app/[locale]/collections/page.tsx
+++ b/apps/static-site/src/app/[locale]/collections/page.tsx
@@ -8,11 +8,19 @@ import { Metadata } from "next";
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
   const t = await getTranslations();
   const siteName = await getSiteName();
-  const page = getMdx({ params: { pageName: "Collections", path: "/collections", locale: params.locale } });
+  const path = "/collections";
+  const page = getMdx({ params: { pageName: "Collections", path: path, locale: params.locale } });
   const title = makeTitle([page.title || t("Collections"), siteName]);
   const description = page.description || t("defaultDesc");
   const image = page.image;
-  return getBasicMetadata(params.locale, siteName, title, description, image);
+  return getBasicMetadata({
+    locale: params.locale,
+    siteName: siteName,
+    title: title,
+    description: description,
+    image: image,
+    path: path,
+  });
 }
 
 export default async function Collections(props: { params: { locale: string } }) {

--- a/apps/static-site/src/app/[locale]/collections/page.tsx
+++ b/apps/static-site/src/app/[locale]/collections/page.tsx
@@ -2,15 +2,17 @@ import { Page } from "@/components/Page";
 import { Slot } from "@/blocks/slot";
 import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
 import { CollectionListing } from "@/components/pages/CollectionListing";
-import { getSiteName, getBasicMetadata, makeTitle } from "@/helpers/metadata";
+import { getSiteName, getBasicMetadata, makeTitle, getMdx } from "@/helpers/metadata";
 import { Metadata } from "next";
 
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
   const t = await getTranslations();
   const siteName = await getSiteName();
-  const title = makeTitle([t("Collections"), siteName]);
-  const description = t("collectionsDesc");
-  return getBasicMetadata(params.locale, siteName, title, description);
+  const page = getMdx({ params: { pageName: "Collections", path: "/collections", locale: params.locale } });
+  const title = makeTitle([page.title || t("Collections"), siteName]);
+  const description = page.description || t("defaultDesc");
+  const image = page.image;
+  return getBasicMetadata(params.locale, siteName, title, description, image);
 }
 
 export default async function Collections(props: { params: { locale: string } }) {

--- a/apps/static-site/src/app/[locale]/collections/page.tsx
+++ b/apps/static-site/src/app/[locale]/collections/page.tsx
@@ -2,20 +2,19 @@ import { Page } from "@/components/Page";
 import { Slot } from "@/blocks/slot";
 import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
 import { CollectionListing } from "@/components/pages/CollectionListing";
-import { getSiteName, getBasicMetadata, makeTitle, getMdx, getDefaultMetaMdx } from "@/helpers/metadata";
+import { getBasicMetadata, makeTitle, getMdx, getDefaultMetaMdx } from "@/helpers/metadata";
 import { Metadata } from "next";
 
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
   const t = await getTranslations();
-  const siteName = await getSiteName();
   const path = "/collections";
   const defaultMeta = getDefaultMetaMdx({ params: { locale: params.locale } });
   const page = getMdx({ params: { pageName: "Collections", path: path, locale: params.locale } });
-  const title = makeTitle([page.title ?? defaultMeta.title, siteName]);
+  const title = makeTitle([page.title, defaultMeta.title]);
   const description = page.description ?? defaultMeta.description;
   return getBasicMetadata({
     locale: params.locale,
-    siteName: siteName,
+    siteName: defaultMeta.title,
     title: title,
     description: description,
     image: {

--- a/apps/static-site/src/app/[locale]/exhibitions/[exhibition]/page.tsx
+++ b/apps/static-site/src/app/[locale]/exhibitions/[exhibition]/page.tsx
@@ -8,7 +8,7 @@ import { SlotContext } from "@/blocks/slot-context";
 import type { Metadata } from "next";
 import { loadManifest, loadManifestMeta } from "@/iiif";
 import { getValue } from "@iiif/helpers";
-import { getSiteName, siteURL, fallbackImage, makeTitle } from "@/helpers/metadata";
+import { getSiteName, baseURL, defaultImage, makeTitle } from "@/helpers/metadata";
 
 export async function generateMetadata({
   params,
@@ -22,9 +22,9 @@ export async function generateMetadata({
   const exTitle = getValue(meta.intlLabel, { language: params.locale, fallbackLanguages: ["nl", "en"] });
   const description = getValue(meta.intlSummary, { language: params.locale, fallbackLanguages: ["nl", "en"] });
   const title = makeTitle([exTitle, siteName]);
-  const objectURL = `${siteURL}/${params.locale}/objects/${params.exhibition}`;
+  const url = `/exhibitions/${params.exhibition}`;
   return {
-    metadataBase: new URL(siteURL),
+    metadataBase: new URL(baseURL),
     description: description,
     title: title,
     openGraph: {
@@ -32,10 +32,10 @@ export async function generateMetadata({
       siteName: siteName,
       title: title,
       type: "website",
-      url: objectURL,
+      url: url,
       images: [
         {
-          url: meta.thumbnail.id || fallbackImage,
+          url: meta.thumbnail.id || defaultImage,
           width: meta.thumbnail.width,
           height: meta.thumbnail.height,
         },

--- a/apps/static-site/src/app/[locale]/exhibitions/[exhibition]/page.tsx
+++ b/apps/static-site/src/app/[locale]/exhibitions/[exhibition]/page.tsx
@@ -8,7 +8,7 @@ import { SlotContext } from "@/blocks/slot-context";
 import type { Metadata } from "next";
 import { loadManifest, loadManifestMeta } from "@/iiif";
 import { getValue } from "@iiif/helpers";
-import { getSiteName, baseURL, defaultImage, makeTitle } from "@/helpers/metadata";
+import { getSiteName, baseURL, makeTitle, getDefaultMetaMdx } from "@/helpers/metadata";
 
 export async function generateMetadata({
   params,
@@ -16,11 +16,14 @@ export async function generateMetadata({
   params: { exhibition: string; locale: string };
 }): Promise<Metadata> {
   const t = await getTranslations();
+  const defaultMeta = getDefaultMetaMdx({ params: { locale: params.locale } });
   const manifestSlug = `manifests/${params.exhibition}`;
   const meta = await loadManifestMeta(manifestSlug);
   const siteName = await getSiteName();
-  const exTitle = getValue(meta.intlLabel, { language: params.locale, fallbackLanguages: ["nl", "en"] });
-  const description = getValue(meta.intlSummary, { language: params.locale, fallbackLanguages: ["nl", "en"] });
+  const exTitle =
+    getValue(meta.intlLabel, { language: params.locale, fallbackLanguages: ["nl", "en"] }) ?? defaultMeta.title;
+  const description =
+    getValue(meta.intlSummary, { language: params.locale, fallbackLanguages: ["nl", "en"] }) ?? defaultMeta.description;
   const title = makeTitle([exTitle, siteName]);
   const url = `/exhibitions/${params.exhibition}`;
   return {
@@ -35,9 +38,9 @@ export async function generateMetadata({
       url: url,
       images: [
         {
-          url: meta.thumbnail.id || defaultImage,
-          width: meta.thumbnail.width,
-          height: meta.thumbnail.height,
+          url: meta.thumbnail.id ?? defaultMeta.image ?? "",
+          width: meta.thumbnail ? meta.thumbnail.width : defaultMeta.imageWidth,
+          height: meta.thumbnail ? meta.thumbnail.height : defaultMeta.imageHeight,
         },
       ],
     },

--- a/apps/static-site/src/app/[locale]/exhibitions/[exhibition]/page.tsx
+++ b/apps/static-site/src/app/[locale]/exhibitions/[exhibition]/page.tsx
@@ -8,7 +8,7 @@ import { SlotContext } from "@/blocks/slot-context";
 import type { Metadata } from "next";
 import { loadManifest, loadManifestMeta } from "@/iiif";
 import { getValue } from "@iiif/helpers";
-import { getSiteName, baseURL, makeTitle, getDefaultMetaMdx } from "@/helpers/metadata";
+import { baseURL, makeTitle, getDefaultMetaMdx } from "@/helpers/metadata";
 
 export async function generateMetadata({
   params,
@@ -19,12 +19,10 @@ export async function generateMetadata({
   const defaultMeta = getDefaultMetaMdx({ params: { locale: params.locale } });
   const manifestSlug = `manifests/${params.exhibition}`;
   const meta = await loadManifestMeta(manifestSlug);
-  const siteName = await getSiteName();
-  const exTitle =
-    getValue(meta.intlLabel, { language: params.locale, fallbackLanguages: ["nl", "en"] }) ?? defaultMeta.title;
+  const exTitle = getValue(meta.intlLabel, { language: params.locale, fallbackLanguages: ["nl", "en"] });
   const description =
     getValue(meta.intlSummary, { language: params.locale, fallbackLanguages: ["nl", "en"] }) ?? defaultMeta.description;
-  const title = makeTitle([exTitle, siteName]);
+  const title = makeTitle([exTitle, defaultMeta.title]);
   const url = `/exhibitions/${params.exhibition}`;
   return {
     metadataBase: new URL(baseURL),
@@ -32,7 +30,7 @@ export async function generateMetadata({
     title: title,
     openGraph: {
       locale: params.locale,
-      siteName: siteName,
+      siteName: defaultMeta.title,
       title: title,
       type: "website",
       url: url,

--- a/apps/static-site/src/app/[locale]/exhibitions/page.tsx
+++ b/apps/static-site/src/app/[locale]/exhibitions/page.tsx
@@ -5,14 +5,16 @@ import { Slot } from "@/blocks/slot";
 import exhibitions from "@repo/iiif/build/collections/exhibitions/collection.json";
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
-import { getSiteName, getBasicMetadata, makeTitle } from "@/helpers/metadata";
+import { getSiteName, getBasicMetadata, makeTitle, getMdx } from "@/helpers/metadata";
 
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
   const t = await getTranslations();
   const siteName = await getSiteName();
-  const title = makeTitle([t("Exhibitions"), siteName]);
-  const description = t("exhibitionsDesc");
-  return getBasicMetadata(params.locale, siteName, title, description);
+  const page = getMdx({ params: { pageName: "Exhibitions", path: "/exhibitions", locale: params.locale } });
+  const title = makeTitle([page.title || t("Exhibitions"), siteName]);
+  const description = page.description || t("defaultDesc");
+  const image = page.image;
+  return getBasicMetadata(params.locale, siteName, title, description, image);
 }
 
 export default function ExhibitionsPage({ params }: { params: { locale: string } }) {

--- a/apps/static-site/src/app/[locale]/exhibitions/page.tsx
+++ b/apps/static-site/src/app/[locale]/exhibitions/page.tsx
@@ -5,22 +5,26 @@ import { Slot } from "@/blocks/slot";
 import exhibitions from "@repo/iiif/build/collections/exhibitions/collection.json";
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
-import { getSiteName, getBasicMetadata, makeTitle, getMdx } from "@/helpers/metadata";
+import { getSiteName, getBasicMetadata, makeTitle, getMdx, getDefaultMetaMdx } from "@/helpers/metadata";
 
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
   const t = await getTranslations();
   const siteName = await getSiteName();
   const path = "/exhibitions";
+  const defaultMeta = getDefaultMetaMdx({ params: { locale: params.locale } });
   const page = getMdx({ params: { pageName: "Exhibitions", path: path, locale: params.locale } });
-  const title = makeTitle([page.title || t("Exhibitions"), siteName]);
-  const description = page.description || t("defaultDesc");
-  const image = page.image;
+  const title = makeTitle([page.title ?? defaultMeta.title, siteName]);
+  const description = page.description ?? defaultMeta.description;
   return getBasicMetadata({
     locale: params.locale,
     siteName: siteName,
     title: title,
     description: description,
-    image: image,
+    image: {
+      url: page.image ?? defaultMeta.image,
+      width: page.image ? page.imageWidth : defaultMeta.imageWidth,
+      height: page.image ? page.imageHeight : defaultMeta.imageWidth,
+    },
     path: path,
   });
 }

--- a/apps/static-site/src/app/[locale]/exhibitions/page.tsx
+++ b/apps/static-site/src/app/[locale]/exhibitions/page.tsx
@@ -5,19 +5,18 @@ import { Slot } from "@/blocks/slot";
 import exhibitions from "@repo/iiif/build/collections/exhibitions/collection.json";
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
-import { getSiteName, getBasicMetadata, makeTitle, getMdx, getDefaultMetaMdx } from "@/helpers/metadata";
+import { getBasicMetadata, makeTitle, getMdx, getDefaultMetaMdx } from "@/helpers/metadata";
 
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
   const t = await getTranslations();
-  const siteName = await getSiteName();
   const path = "/exhibitions";
   const defaultMeta = getDefaultMetaMdx({ params: { locale: params.locale } });
   const page = getMdx({ params: { pageName: "Exhibitions", path: path, locale: params.locale } });
-  const title = makeTitle([page.title ?? defaultMeta.title, siteName]);
+  const title = makeTitle([page.title, defaultMeta.title]);
   const description = page.description ?? defaultMeta.description;
   return getBasicMetadata({
     locale: params.locale,
-    siteName: siteName,
+    siteName: defaultMeta.title,
     title: title,
     description: description,
     image: {

--- a/apps/static-site/src/app/[locale]/exhibitions/page.tsx
+++ b/apps/static-site/src/app/[locale]/exhibitions/page.tsx
@@ -10,11 +10,19 @@ import { getSiteName, getBasicMetadata, makeTitle, getMdx } from "@/helpers/meta
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
   const t = await getTranslations();
   const siteName = await getSiteName();
-  const page = getMdx({ params: { pageName: "Exhibitions", path: "/exhibitions", locale: params.locale } });
+  const path = "/exhibitions";
+  const page = getMdx({ params: { pageName: "Exhibitions", path: path, locale: params.locale } });
   const title = makeTitle([page.title || t("Exhibitions"), siteName]);
   const description = page.description || t("defaultDesc");
   const image = page.image;
-  return getBasicMetadata(params.locale, siteName, title, description, image);
+  return getBasicMetadata({
+    locale: params.locale,
+    siteName: siteName,
+    title: title,
+    description: description,
+    image: image,
+    path: path,
+  });
 }
 
 export default function ExhibitionsPage({ params }: { params: { locale: string } }) {

--- a/apps/static-site/src/app/[locale]/layout.tsx
+++ b/apps/static-site/src/app/[locale]/layout.tsx
@@ -14,11 +14,19 @@ import { $ } from "bun";
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
   const t = await getTranslations();
   const siteName = await getSiteName();
-  const page = getMdx({ params: { pageName: "Home", path: "/", locale: params.locale } });
+  const path = "/";
+  const page = getMdx({ params: { pageName: "Home", path: path, locale: params.locale } });
   const title = makeTitle([page.title, siteName]);
   const description = page.description || t("defaultDesc");
   const image = page.image;
-  return getBasicMetadata(params.locale, siteName, title, description, image);
+  return getBasicMetadata({
+    locale: params.locale,
+    siteName: siteName,
+    title: title,
+    description: description,
+    image: image,
+    path: path,
+  });
 }
 
 if (process.env.NODE_ENV !== "production") {

--- a/apps/static-site/src/app/[locale]/layout.tsx
+++ b/apps/static-site/src/app/[locale]/layout.tsx
@@ -8,15 +8,17 @@ import { GlobalHeader } from "@/components/GlobalHeader";
 import localFont from "next/font/local";
 import { SlotContext } from "@/blocks/slot-context";
 import { GlobalFooter } from "@/components/GlobalFooter";
-import { getSiteName, getBasicMetadata } from "@/helpers/metadata";
+import { getSiteName, getBasicMetadata, makeTitle, getMdx } from "@/helpers/metadata";
 import { $ } from "bun";
 
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
   const t = await getTranslations();
   const siteName = await getSiteName();
-  const title = siteName;
-  const description = t("homeDesc");
-  return getBasicMetadata(params.locale, siteName, title, description);
+  const page = getMdx({ params: { pageName: "Home", path: "/", locale: params.locale } });
+  const title = makeTitle([page.title, siteName]);
+  const description = page.description || t("defaultDesc");
+  const image = page.image;
+  return getBasicMetadata(params.locale, siteName, title, description, image);
 }
 
 if (process.env.NODE_ENV !== "production") {

--- a/apps/static-site/src/app/[locale]/layout.tsx
+++ b/apps/static-site/src/app/[locale]/layout.tsx
@@ -8,20 +8,18 @@ import { GlobalHeader } from "@/components/GlobalHeader";
 import localFont from "next/font/local";
 import { SlotContext } from "@/blocks/slot-context";
 import { GlobalFooter } from "@/components/GlobalFooter";
-import { getSiteName, getBasicMetadata, getMdx } from "@/helpers/metadata";
+import { getBasicMetadata, getMdx } from "@/helpers/metadata";
 import { $ } from "bun";
 
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
   const t = await getTranslations();
-  const siteName = await getSiteName();
   const path = "/";
   const page = getMdx({ params: { pageName: "Home", path: path, locale: params.locale } });
-  const title = page.title; //n.b. unlike other pages, the homepage does not append "| TU Delft Academic Heritage" to the title.
   const description = page.description;
   return getBasicMetadata({
     locale: params.locale,
-    siteName: siteName,
-    title: title,
+    siteName: page.title,
+    title: page.title,
     description: description,
     image: {
       url: page.image,

--- a/apps/static-site/src/app/[locale]/layout.tsx
+++ b/apps/static-site/src/app/[locale]/layout.tsx
@@ -8,7 +8,7 @@ import { GlobalHeader } from "@/components/GlobalHeader";
 import localFont from "next/font/local";
 import { SlotContext } from "@/blocks/slot-context";
 import { GlobalFooter } from "@/components/GlobalFooter";
-import { getSiteName, getBasicMetadata, makeTitle, getMdx } from "@/helpers/metadata";
+import { getSiteName, getBasicMetadata, getMdx } from "@/helpers/metadata";
 import { $ } from "bun";
 
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
@@ -16,15 +16,18 @@ export async function generateMetadata({ params }: { params: { locale: string } 
   const siteName = await getSiteName();
   const path = "/";
   const page = getMdx({ params: { pageName: "Home", path: path, locale: params.locale } });
-  const title = makeTitle([page.title, siteName]);
-  const description = page.description || t("defaultDesc");
-  const image = page.image;
+  const title = page.title; //n.b. unlike other pages, the homepage does not append "| TU Delft Academic Heritage" to the title.
+  const description = page.description;
   return getBasicMetadata({
     locale: params.locale,
     siteName: siteName,
     title: title,
     description: description,
-    image: image,
+    image: {
+      url: page.image,
+      width: page.imageWidth,
+      height: page.imageHeight,
+    },
     path: path,
   });
 }

--- a/apps/static-site/src/app/[locale]/objects/[manifest]/page.tsx
+++ b/apps/static-site/src/app/[locale]/objects/[manifest]/page.tsx
@@ -6,7 +6,7 @@ import { ManifestLoader } from "@/app/provider";
 import related from "@repo/iiif/build/meta/related-objects.json";
 import type { Metadata } from "next";
 import { getValue } from "@iiif/helpers";
-import { getSiteName, baseURL, makeTitle, getDefaultMetaMdx } from "@/helpers/metadata";
+import { baseURL, makeTitle, getDefaultMetaMdx } from "@/helpers/metadata";
 
 export async function generateMetadata({
   params,
@@ -17,12 +17,10 @@ export async function generateMetadata({
   const defaultMeta = getDefaultMetaMdx({ params: { locale: params.locale } });
   const manifestSlug = `manifests/${params.manifest}`;
   const meta = await loadManifestMeta(manifestSlug);
-  const objTitle =
-    getValue(meta.intlLabel, { language: params.locale, fallbackLanguages: ["nl", "en"] }) ?? defaultMeta.title;
+  const objTitle = getValue(meta.intlLabel, { language: params.locale, fallbackLanguages: ["nl", "en"] });
   const description =
     getValue(meta.intlSummary, { language: params.locale, fallbackLanguages: ["nl", "en"] }) ?? defaultMeta.description;
-  const siteName = await getSiteName();
-  const title = makeTitle([objTitle, siteName]);
+  const title = makeTitle([objTitle, defaultMeta.title]);
   const url = `/objects/${params.manifest}`;
   return {
     metadataBase: new URL(baseURL),
@@ -30,7 +28,7 @@ export async function generateMetadata({
     title: title,
     openGraph: {
       locale: params.locale,
-      siteName: siteName,
+      siteName: defaultMeta.title,
       title: title,
       type: "website",
       url: url,

--- a/apps/static-site/src/app/[locale]/objects/[manifest]/page.tsx
+++ b/apps/static-site/src/app/[locale]/objects/[manifest]/page.tsx
@@ -6,7 +6,7 @@ import { ManifestLoader } from "@/app/provider";
 import related from "@repo/iiif/build/meta/related-objects.json";
 import type { Metadata } from "next";
 import { getValue } from "@iiif/helpers";
-import { getSiteName, baseURL, defaultImage, makeTitle } from "@/helpers/metadata";
+import { getSiteName, baseURL, makeTitle, getDefaultMetaMdx } from "@/helpers/metadata";
 
 export async function generateMetadata({
   params,
@@ -14,10 +14,13 @@ export async function generateMetadata({
   params: { manifest: string; locale: string };
 }): Promise<Metadata> {
   const t = await getTranslations();
+  const defaultMeta = getDefaultMetaMdx({ params: { locale: params.locale } });
   const manifestSlug = `manifests/${params.manifest}`;
   const meta = await loadManifestMeta(manifestSlug);
-  const objTitle = getValue(meta.intlLabel, { language: params.locale, fallbackLanguages: ["nl", "en"] });
-  const description = getValue(meta.intlSummary, { language: params.locale, fallbackLanguages: ["nl", "en"] });
+  const objTitle =
+    getValue(meta.intlLabel, { language: params.locale, fallbackLanguages: ["nl", "en"] }) ?? defaultMeta.title;
+  const description =
+    getValue(meta.intlSummary, { language: params.locale, fallbackLanguages: ["nl", "en"] }) ?? defaultMeta.description;
   const siteName = await getSiteName();
   const title = makeTitle([objTitle, siteName]);
   const url = `/objects/${params.manifest}`;
@@ -33,9 +36,9 @@ export async function generateMetadata({
       url: url,
       images: [
         {
-          url: meta.thumbnail.id || defaultImage,
-          width: meta.thumbnail.width,
-          height: meta.thumbnail.height,
+          url: meta.thumbnail.id ?? defaultMeta.image ?? "",
+          width: meta.thumbnail ? meta.thumbnail.width : defaultMeta.imageWidth,
+          height: meta.thumbnail ? meta.thumbnail.height : defaultMeta.imageHeight,
         },
       ],
     },

--- a/apps/static-site/src/app/[locale]/objects/[manifest]/page.tsx
+++ b/apps/static-site/src/app/[locale]/objects/[manifest]/page.tsx
@@ -6,7 +6,7 @@ import { ManifestLoader } from "@/app/provider";
 import related from "@repo/iiif/build/meta/related-objects.json";
 import type { Metadata } from "next";
 import { getValue } from "@iiif/helpers";
-import { getSiteName, siteURL, fallbackImage, makeTitle } from "@/helpers/metadata";
+import { getSiteName, baseURL, defaultImage, makeTitle } from "@/helpers/metadata";
 
 export async function generateMetadata({
   params,
@@ -20,9 +20,9 @@ export async function generateMetadata({
   const description = getValue(meta.intlSummary, { language: params.locale, fallbackLanguages: ["nl", "en"] });
   const siteName = await getSiteName();
   const title = makeTitle([objTitle, siteName]);
-  const objectURL = `${siteURL}/${params.locale}/objects/${params.manifest}`;
+  const url = `/objects/${params.manifest}`;
   return {
-    metadataBase: new URL(siteURL),
+    metadataBase: new URL(baseURL),
     description: description,
     title: title,
     openGraph: {
@@ -30,10 +30,10 @@ export async function generateMetadata({
       siteName: siteName,
       title: title,
       type: "website",
-      url: objectURL,
+      url: url,
       images: [
         {
-          url: meta.thumbnail.id || fallbackImage,
+          url: meta.thumbnail.id || defaultImage,
           width: meta.thumbnail.width,
           height: meta.thumbnail.height,
         },

--- a/apps/static-site/src/app/[locale]/publications/[publication]/page.tsx
+++ b/apps/static-site/src/app/[locale]/publications/[publication]/page.tsx
@@ -4,7 +4,7 @@ import { PublicationPage } from "@/components/pages/PublicationPage";
 import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
 import type { Metadata } from "next";
 import { getValue } from "@iiif/helpers";
-import { getSiteName, baseURL, defaultImage, makeTitle } from "@/helpers/metadata";
+import { getSiteName, baseURL, makeTitle, getDefaultMetaMdx } from "@/helpers/metadata";
 
 export async function generateMetadata({
   params,
@@ -12,23 +12,23 @@ export async function generateMetadata({
   params: { publication: string; locale: string };
 }): Promise<Metadata> {
   const t = await getTranslations();
+  const defaultMeta = getDefaultMetaMdx({ params: { locale: params.locale } });
   const getValueParams = { language: params.locale, fallbackLanguages: ["nl", "en"] };
   const publicationInLanguage = allPublications.find(
     (post) => post.id === params.publication && post.lang === params.locale
   );
   const publication = publicationInLanguage || allPublications.find((post) => post.id === params.publication);
-  const pubTitle = publication && getValue(publication.title, getValueParams);
+  const pubTitle = (publication && getValue(publication.title, getValueParams)) ?? defaultMeta.title;
   const siteName = await getSiteName();
   const title = makeTitle([pubTitle, siteName]);
-  const description = publication && getValue(publication.description, getValueParams);
+  const description = (publication && getValue(publication.description, getValueParams)) ?? defaultMeta.description;
   const author = {
     name: (publication && getValue(publication.author, getValueParams)) || "",
   };
   const pubDateStr = publication && getValue(publication.date, getValueParams);
   const pubDate = pubDateStr && new Date(pubDateStr).toISOString();
   const publicationsURL = `/publications`;
-  const image =
-    publication && getValue(publication.image, { language: params.locale, fallbackLanguages: ["nl", "en"] });
+
   return {
     metadataBase: new URL(baseURL),
     authors: author,
@@ -44,8 +44,9 @@ export async function generateMetadata({
       url: publication ? `${publicationsURL}/${publication.id}` : publicationsURL,
       images: [
         {
-          url: image || defaultImage,
-          width: 1080,
+          url: publication?.image ?? defaultMeta.image ?? "",
+          width: publication?.image ? publication?.imageWidth : defaultMeta.imageWidth,
+          height: publication?.image ? publication?.imageHeight : defaultMeta.imageHeight,
         },
       ],
     },

--- a/apps/static-site/src/app/[locale]/publications/[publication]/page.tsx
+++ b/apps/static-site/src/app/[locale]/publications/[publication]/page.tsx
@@ -4,7 +4,7 @@ import { PublicationPage } from "@/components/pages/PublicationPage";
 import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
 import type { Metadata } from "next";
 import { getValue } from "@iiif/helpers";
-import { getSiteName, baseURL, makeTitle, getDefaultMetaMdx } from "@/helpers/metadata";
+import { baseURL, makeTitle, getDefaultMetaMdx } from "@/helpers/metadata";
 
 export async function generateMetadata({
   params,
@@ -18,9 +18,8 @@ export async function generateMetadata({
     (post) => post.id === params.publication && post.lang === params.locale
   );
   const publication = publicationInLanguage || allPublications.find((post) => post.id === params.publication);
-  const pubTitle = (publication && getValue(publication.title, getValueParams)) ?? defaultMeta.title;
-  const siteName = await getSiteName();
-  const title = makeTitle([pubTitle, siteName]);
+  const pubTitle = publication && getValue(publication.title, getValueParams);
+  const title = makeTitle([pubTitle, defaultMeta.title]);
   const description = (publication && getValue(publication.description, getValueParams)) ?? defaultMeta.description;
   const author = {
     name: (publication && getValue(publication.author, getValueParams)) || "",
@@ -38,7 +37,7 @@ export async function generateMetadata({
       authors: [author.name],
       locale: params.locale,
       publishedTime: pubDate,
-      siteName: siteName,
+      siteName: defaultMeta.title,
       title: title,
       type: "article",
       url: publication ? `${publicationsURL}/${publication.id}` : publicationsURL,

--- a/apps/static-site/src/app/[locale]/publications/[publication]/page.tsx
+++ b/apps/static-site/src/app/[locale]/publications/[publication]/page.tsx
@@ -4,7 +4,7 @@ import { PublicationPage } from "@/components/pages/PublicationPage";
 import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
 import type { Metadata } from "next";
 import { getValue } from "@iiif/helpers";
-import { getSiteName, siteURL, fallbackImage, makeTitle } from "@/helpers/metadata";
+import { getSiteName, baseURL, defaultImage, makeTitle } from "@/helpers/metadata";
 
 export async function generateMetadata({
   params,
@@ -26,11 +26,11 @@ export async function generateMetadata({
   };
   const pubDateStr = publication && getValue(publication.date, getValueParams);
   const pubDate = pubDateStr && new Date(pubDateStr).toISOString();
-  const publicationsURL = `${siteURL}/${params.locale}/publications`;
+  const publicationsURL = `/publications`;
   const image =
     publication && getValue(publication.image, { language: params.locale, fallbackLanguages: ["nl", "en"] });
   return {
-    metadataBase: new URL(siteURL),
+    metadataBase: new URL(baseURL),
     authors: author,
     title: title,
     description: description,
@@ -44,7 +44,7 @@ export async function generateMetadata({
       url: publication ? `${publicationsURL}/${publication.id}` : publicationsURL,
       images: [
         {
-          url: image || fallbackImage,
+          url: image || defaultImage,
           width: 1080,
         },
       ],

--- a/apps/static-site/src/app/[locale]/publications/page.tsx
+++ b/apps/static-site/src/app/[locale]/publications/page.tsx
@@ -3,14 +3,17 @@ import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
 import { PublicationListPage } from "@/components/pages/PublicationListPage";
 import { Page } from "@/components/Page";
 import { Metadata } from "next";
-import { getSiteName, getBasicMetadata, makeTitle } from "@/helpers/metadata";
+import { getSiteName, getBasicMetadata, makeTitle, getMdx } from "@/helpers/metadata";
 
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
   const t = await getTranslations();
   const siteName = await getSiteName();
-  const title = makeTitle([t("Publications"), siteName]);
-  const description = t("publicationsDesc");
-  return getBasicMetadata(params.locale, siteName, title, description);
+  const page = getMdx({ params: { pageName: "Publications", path: "/publications", locale: params.locale } });
+  const title = makeTitle([page.title || t("Publications"), siteName]);
+  const description = page.description || t("defaultDesc");
+  const image = page.image;
+
+  return getBasicMetadata(params.locale, siteName, title, description, image);
 }
 
 export default async function PublicationsList({ params }: { params: { locale: string } }) {

--- a/apps/static-site/src/app/[locale]/publications/page.tsx
+++ b/apps/static-site/src/app/[locale]/publications/page.tsx
@@ -8,12 +8,19 @@ import { getSiteName, getBasicMetadata, makeTitle, getMdx } from "@/helpers/meta
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
   const t = await getTranslations();
   const siteName = await getSiteName();
-  const page = getMdx({ params: { pageName: "Publications", path: "/publications", locale: params.locale } });
+  const path = "/publications";
+  const page = getMdx({ params: { pageName: "Publications", path: path, locale: params.locale } });
   const title = makeTitle([page.title || t("Publications"), siteName]);
   const description = page.description || t("defaultDesc");
   const image = page.image;
-
-  return getBasicMetadata(params.locale, siteName, title, description, image);
+  return getBasicMetadata({
+    locale: params.locale,
+    siteName: siteName,
+    title: title,
+    description: description,
+    image: image,
+    path: path,
+  });
 }
 
 export default async function PublicationsList({ params }: { params: { locale: string } }) {

--- a/apps/static-site/src/app/[locale]/publications/page.tsx
+++ b/apps/static-site/src/app/[locale]/publications/page.tsx
@@ -3,22 +3,26 @@ import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
 import { PublicationListPage } from "@/components/pages/PublicationListPage";
 import { Page } from "@/components/Page";
 import { Metadata } from "next";
-import { getSiteName, getBasicMetadata, makeTitle, getMdx } from "@/helpers/metadata";
+import { getSiteName, getBasicMetadata, makeTitle, getMdx, getDefaultMetaMdx } from "@/helpers/metadata";
 
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
   const t = await getTranslations();
   const siteName = await getSiteName();
   const path = "/publications";
+  const defaultMeta = getDefaultMetaMdx({ params: { locale: params.locale } });
   const page = getMdx({ params: { pageName: "Publications", path: path, locale: params.locale } });
-  const title = makeTitle([page.title || t("Publications"), siteName]);
-  const description = page.description || t("defaultDesc");
-  const image = page.image;
+  const title = makeTitle([page.title ?? defaultMeta.title, siteName]);
+  const description = page.description ?? defaultMeta.description;
   return getBasicMetadata({
     locale: params.locale,
     siteName: siteName,
     title: title,
     description: description,
-    image: image,
+    image: {
+      url: page.image ?? defaultMeta.image,
+      width: page.image ? page.imageWidth : defaultMeta.imageWidth,
+      height: page.image ? page.imageHeight : defaultMeta.imageWidth,
+    },
     path: path,
   });
 }

--- a/apps/static-site/src/app/[locale]/publications/page.tsx
+++ b/apps/static-site/src/app/[locale]/publications/page.tsx
@@ -3,19 +3,18 @@ import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
 import { PublicationListPage } from "@/components/pages/PublicationListPage";
 import { Page } from "@/components/Page";
 import { Metadata } from "next";
-import { getSiteName, getBasicMetadata, makeTitle, getMdx, getDefaultMetaMdx } from "@/helpers/metadata";
+import { getBasicMetadata, makeTitle, getMdx, getDefaultMetaMdx } from "@/helpers/metadata";
 
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
   const t = await getTranslations();
-  const siteName = await getSiteName();
   const path = "/publications";
   const defaultMeta = getDefaultMetaMdx({ params: { locale: params.locale } });
   const page = getMdx({ params: { pageName: "Publications", path: path, locale: params.locale } });
-  const title = makeTitle([page.title ?? defaultMeta.title, siteName]);
+  const title = makeTitle([page.title, defaultMeta.title]);
   const description = page.description ?? defaultMeta.description;
   return getBasicMetadata({
     locale: params.locale,
-    siteName: siteName,
+    siteName: defaultMeta.title,
     title: title,
     description: description,
     image: {

--- a/apps/static-site/src/app/[locale]/search/page.tsx
+++ b/apps/static-site/src/app/[locale]/search/page.tsx
@@ -2,22 +2,24 @@ import { SearchPage } from "@/components/pages/SearchPage";
 import { Page } from "@/components/Page";
 import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
 import { Metadata } from "next";
-import { getSiteName, getBasicMetadata, makeTitle } from "@/helpers/metadata";
+import { getSiteName, getBasicMetadata, makeTitle, getMdx } from "@/helpers/metadata";
 
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
   const t = await getTranslations();
   const siteName = await getSiteName();
-  const title = makeTitle([t("Search"), siteName]);
-  const description = t("searchDesc");
-  return getBasicMetadata(params.locale, siteName, title, description);
+  const page = getMdx({ params: { pageName: "Search", path: "/search", locale: params.locale } });
+  const title = makeTitle([page.title || t("Search"), siteName]);
+  const description = page.description || t("defaultDesc");
+  const image = page.image;
+  return getBasicMetadata(params.locale, siteName, title, description, image);
 }
 
 export default async function Search({ params }: { params: { locale: string } }) {
   unstable_setRequestLocale(params.locale);
-  const t = await getTranslations();
+  const page = getMdx({ params: { pageName: "Search", path: "/search", locale: params.locale } });
   return (
     <Page>
-      <SearchPage title={t("Search")} />
+      <SearchPage title={page.title} />
     </Page>
   );
 }

--- a/apps/static-site/src/app/[locale]/search/page.tsx
+++ b/apps/static-site/src/app/[locale]/search/page.tsx
@@ -2,22 +2,27 @@ import { SearchPage } from "@/components/pages/SearchPage";
 import { Page } from "@/components/Page";
 import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
 import { Metadata } from "next";
-import { getSiteName, getBasicMetadata, makeTitle, getMdx } from "@/helpers/metadata";
+import { getSiteName, getBasicMetadata, makeTitle, getMdx, getDefaultMetaMdx } from "@/helpers/metadata";
 
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
   const t = await getTranslations();
   const siteName = await getSiteName();
   const path = "/search";
+  const defaultMeta = getDefaultMetaMdx({ params: { locale: params.locale } });
   const page = getMdx({ params: { pageName: "Search", path: path, locale: params.locale } });
-  const title = makeTitle([page.title || t("Search"), siteName]);
-  const description = page.description || t("defaultDesc");
+  const title = makeTitle([page.title ?? defaultMeta.title, siteName]);
+  const description = page.description ?? defaultMeta.description;
   const image = page.image;
   return getBasicMetadata({
     locale: params.locale,
     siteName: siteName,
     title: title,
     description: description,
-    image: image,
+    image: {
+      url: page.image ?? defaultMeta.image,
+      width: page.image ? page.imageWidth : defaultMeta.imageWidth,
+      height: page.image ? page.imageHeight : defaultMeta.imageWidth,
+    },
     path: path,
   });
 }

--- a/apps/static-site/src/app/[locale]/search/page.tsx
+++ b/apps/static-site/src/app/[locale]/search/page.tsx
@@ -2,20 +2,19 @@ import { SearchPage } from "@/components/pages/SearchPage";
 import { Page } from "@/components/Page";
 import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
 import { Metadata } from "next";
-import { getSiteName, getBasicMetadata, makeTitle, getMdx, getDefaultMetaMdx } from "@/helpers/metadata";
+import { getBasicMetadata, makeTitle, getMdx, getDefaultMetaMdx } from "@/helpers/metadata";
 
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
   const t = await getTranslations();
-  const siteName = await getSiteName();
   const path = "/search";
   const defaultMeta = getDefaultMetaMdx({ params: { locale: params.locale } });
   const page = getMdx({ params: { pageName: "Search", path: path, locale: params.locale } });
-  const title = makeTitle([page.title ?? defaultMeta.title, siteName]);
+  const title = makeTitle([page.title, defaultMeta.title]);
   const description = page.description ?? defaultMeta.description;
   const image = page.image;
   return getBasicMetadata({
     locale: params.locale,
-    siteName: siteName,
+    siteName: defaultMeta.title,
     title: title,
     description: description,
     image: {

--- a/apps/static-site/src/app/[locale]/search/page.tsx
+++ b/apps/static-site/src/app/[locale]/search/page.tsx
@@ -7,11 +7,19 @@ import { getSiteName, getBasicMetadata, makeTitle, getMdx } from "@/helpers/meta
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
   const t = await getTranslations();
   const siteName = await getSiteName();
-  const page = getMdx({ params: { pageName: "Search", path: "/search", locale: params.locale } });
+  const path = "/search";
+  const page = getMdx({ params: { pageName: "Search", path: path, locale: params.locale } });
   const title = makeTitle([page.title || t("Search"), siteName]);
   const description = page.description || t("defaultDesc");
   const image = page.image;
-  return getBasicMetadata(params.locale, siteName, title, description, image);
+  return getBasicMetadata({
+    locale: params.locale,
+    siteName: siteName,
+    title: title,
+    description: description,
+    image: image,
+    path: path,
+  });
 }
 
 export default async function Search({ params }: { params: { locale: string } }) {

--- a/apps/static-site/src/helpers/metadata.ts
+++ b/apps/static-site/src/helpers/metadata.ts
@@ -2,8 +2,7 @@ import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { allPages } from ".contentlayer/generated";
 
-export const siteURL = "https://heritage.tudelft.nl";
-export const fallbackImage = "/logo/TUDelft_logo_rgb.png";
+export const baseURL = process.env["DEPLOY_PRIME_URL"] || "http://localhost:3000";
 
 export async function getSiteName() {
   const t = await getTranslations();
@@ -23,31 +22,34 @@ export function makeTitle(parts: (string | undefined | null)[]) {
 
 export const defaultImage = "/metadata/default.jpg";
 
-export function getBasicMetadata(
-  locale: string,
-  siteName: string,
-  title: string,
-  description: string,
-  image: string | null | undefined
-): Metadata {
+type GetBasicMetadataProps = {
+  locale: string;
+  siteName: string;
+  title: string;
+  description: string;
+  image: string | null | undefined;
+  path: string;
+};
+
+export function getBasicMetadata(params: GetBasicMetadataProps): Metadata {
   return {
-    metadataBase: new URL(siteURL),
-    title: title,
-    description: description,
+    metadataBase: new URL(baseURL),
+    title: params.title,
+    description: params.description,
     openGraph: {
-      title: title,
-      description: description,
+      title: params.title,
+      description: params.description,
       images: [
         {
-          url: image || defaultImage,
+          url: params.image || defaultImage,
           width: 800,
           height: 800,
         },
       ],
-      locale: locale,
-      siteName: siteName,
+      locale: params.locale,
+      siteName: params.siteName,
       type: "website",
-      url: "https://heritage.tudelft.nl/",
+      url: `${params.locale}${params.path}`,
     },
   };
 }

--- a/apps/static-site/src/helpers/metadata.ts
+++ b/apps/static-site/src/helpers/metadata.ts
@@ -4,7 +4,7 @@ import { allPages } from ".contentlayer/generated";
 import { T } from "@iiif/helpers/dist/vault-actions-FZxiP2q-";
 import { U } from "react-iiif-vault/dist/useRenderingStrategy-2EaRC2Nc";
 
-export const baseURL = process.env["URL"] ?? process.env["SITE_BASE_URL"] ?? "http://localhost:3000";
+export const baseURL = process.env["SITE_BASE_URL"] ?? "http://localhost:3000";
 
 // Removes any parts that have no value (i.e. collection title if label is "")
 export function makeTitle(parts: (string | undefined | null)[]) {

--- a/apps/static-site/src/helpers/metadata.ts
+++ b/apps/static-site/src/helpers/metadata.ts
@@ -1,5 +1,6 @@
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
+import { allPages } from ".contentlayer/generated";
 
 export const siteURL = "https://heritage.tudelft.nl";
 export const fallbackImage = "/logo/TUDelft_logo_rgb.png";
@@ -20,7 +21,15 @@ export function makeTitle(parts: (string | undefined | null)[]) {
   return partsArray.join(" | ");
 }
 
-export function getBasicMetadata(locale: string, siteName: string, title: string, description: string): Metadata {
+export const defaultImage = "/metadata/default.jpg";
+
+export function getBasicMetadata(
+  locale: string,
+  siteName: string,
+  title: string,
+  description: string,
+  image: string | null | undefined
+): Metadata {
   return {
     metadataBase: new URL(siteURL),
     title: title,
@@ -30,7 +39,7 @@ export function getBasicMetadata(locale: string, siteName: string, title: string
       description: description,
       images: [
         {
-          url: "/metadata/default.jpg",
+          url: image || defaultImage,
           width: 800,
           height: 800,
         },
@@ -41,4 +50,11 @@ export function getBasicMetadata(locale: string, siteName: string, title: string
       url: "https://heritage.tudelft.nl/",
     },
   };
+}
+
+export function getMdx({ params }: { params: { pageName: string; path: string; locale: string } }) {
+  const pages = allPages.filter((page) => page.path === params.path);
+  const page = pages.find((p) => p.lang === params.locale) || pages[0];
+  if (!page) throw new Error(`No ${params.pageName} page found for locale ${params.locale}`);
+  return page;
 }

--- a/apps/static-site/src/helpers/metadata.ts
+++ b/apps/static-site/src/helpers/metadata.ts
@@ -4,7 +4,7 @@ import { allPages } from ".contentlayer/generated";
 import { T } from "@iiif/helpers/dist/vault-actions-FZxiP2q-";
 import { U } from "react-iiif-vault/dist/useRenderingStrategy-2EaRC2Nc";
 
-export const baseURL = process.env["DEPLOY_PRIME_URL"] || "http://localhost:3000";
+export const baseURL = process.env["URL"] ?? process.env["SITE_BASE_URL"] ?? "http://localhost:3000";
 
 // Removes any parts that have no value (i.e. collection title if label is "")
 export function makeTitle(parts: (string | undefined | null)[]) {

--- a/apps/static-site/src/helpers/metadata.ts
+++ b/apps/static-site/src/helpers/metadata.ts
@@ -4,7 +4,7 @@ import { allPages } from ".contentlayer/generated";
 import { T } from "@iiif/helpers/dist/vault-actions-FZxiP2q-";
 import { U } from "react-iiif-vault/dist/useRenderingStrategy-2EaRC2Nc";
 
-export const baseURL = process.env["SITE_BASE_URL"] ?? "http://localhost:3000";
+export const baseURL = process.env["URL"] ?? "http://localhost:3000";
 
 // Removes any parts that have no value (i.e. collection title if label is "")
 export function makeTitle(parts: (string | undefined | null)[]) {

--- a/apps/static-site/src/helpers/metadata.ts
+++ b/apps/static-site/src/helpers/metadata.ts
@@ -1,12 +1,14 @@
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { allPages } from ".contentlayer/generated";
+import { T } from "@iiif/helpers/dist/vault-actions-FZxiP2q-";
+import { U } from "react-iiif-vault/dist/useRenderingStrategy-2EaRC2Nc";
 
 export const baseURL = process.env["DEPLOY_PRIME_URL"] || "http://localhost:3000";
 
 export async function getSiteName() {
   const t = await getTranslations();
-  return `TU Delft ${t("Academic Heritage")}`;
+  return t("TU Delft Academic Heritage");
 }
 
 // Removes any parts that have no value (i.e. collection title if label is "")
@@ -20,18 +22,21 @@ export function makeTitle(parts: (string | undefined | null)[]) {
   return partsArray.join(" | ");
 }
 
-export const defaultImage = "/metadata/default.jpg";
-
 type GetBasicMetadataProps = {
   locale: string;
   siteName: string;
-  title: string;
-  description: string;
-  image: string | null | undefined;
+  title: string | undefined;
+  description: string | undefined;
+  image: {
+    url: string | null | undefined;
+    width: number | undefined;
+    height: number | undefined;
+  };
   path: string;
 };
 
 export function getBasicMetadata(params: GetBasicMetadataProps): Metadata {
+  const defaultPage = getDefaultMetaMdx({ params: { locale: params.locale } });
   return {
     metadataBase: new URL(baseURL),
     title: params.title,
@@ -41,9 +46,9 @@ export function getBasicMetadata(params: GetBasicMetadataProps): Metadata {
       description: params.description,
       images: [
         {
-          url: params.image || defaultImage,
-          width: 800,
-          height: 800,
+          url: params.image.url ?? defaultPage.image ?? "",
+          width: defaultPage.imageWidth ?? undefined,
+          height: defaultPage.imageHeight ?? undefined,
         },
       ],
       locale: params.locale,
@@ -56,7 +61,17 @@ export function getBasicMetadata(params: GetBasicMetadataProps): Metadata {
 
 export function getMdx({ params }: { params: { pageName: string; path: string; locale: string } }) {
   const pages = allPages.filter((page) => page.path === params.path);
-  const page = pages.find((p) => p.lang === params.locale) || pages[0];
+  const page = pages.find((p) => p.lang === params.locale) ?? pages[0];
   if (!page) throw new Error(`No ${params.pageName} page found for locale ${params.locale}`);
   return page;
+}
+
+export function getDefaultMetaMdx({ params }: { params: { locale: string } }) {
+  return getMdx({
+    params: {
+      pageName: "Home",
+      path: "/",
+      locale: params.locale,
+    },
+  });
 }

--- a/apps/static-site/src/helpers/metadata.ts
+++ b/apps/static-site/src/helpers/metadata.ts
@@ -6,11 +6,6 @@ import { U } from "react-iiif-vault/dist/useRenderingStrategy-2EaRC2Nc";
 
 export const baseURL = process.env["DEPLOY_PRIME_URL"] || "http://localhost:3000";
 
-export async function getSiteName() {
-  const t = await getTranslations();
-  return t("TU Delft Academic Heritage");
-}
-
 // Removes any parts that have no value (i.e. collection title if label is "")
 export function makeTitle(parts: (string | undefined | null)[]) {
   let partsArray: string[] = [];

--- a/apps/static-site/src/iiif.ts
+++ b/apps/static-site/src/iiif.ts
@@ -24,8 +24,10 @@ export async function loadCollection(slug: string) {
 
 export async function loadCollectionMeta(slug: string) {
   const resp = await fetch(`${IIIF_URL}${slug}/meta.json`);
+
   if (resp.ok) {
-    return resp.json();
+    const json = await resp.json();
+    return json;
   }
 }
 

--- a/apps/static-site/translations/en.json
+++ b/apps/static-site/translations/en.json
@@ -25,6 +25,7 @@
   "Article": "Article",
   "Table of contents": "Table of contents",
   "Summary": "Summary",
+  "TU Delft Academic Heritage": "TU Delft Academic Heritage",
   "defaultTitle": "Academic Heritage, History and Art",
   "defaultDesc": "Explore the history of Delft University of Technology and the Special Collections of TU Delft Library"
 }

--- a/apps/static-site/translations/en.json
+++ b/apps/static-site/translations/en.json
@@ -25,7 +25,6 @@
   "Article": "Article",
   "Table of contents": "Table of contents",
   "Summary": "Summary",
-  "TU Delft Academic Heritage": "TU Delft Academic Heritage",
   "defaultTitle": "Academic Heritage, History and Art",
   "defaultDesc": "Explore the history of Delft University of Technology and the Special Collections of TU Delft Library"
 }

--- a/apps/static-site/translations/en.json
+++ b/apps/static-site/translations/en.json
@@ -24,11 +24,6 @@
   "Contact and accessibility": "Contact and accessibility",
   "Article": "Article",
   "Table of contents": "Table of contents",
-  "homeTitle": "Academic Heritage, History and Art",
-  "homeDesc": "Explore the history of Delft University of Technology and the Special Collections of TU Delft Library",
-  "aboutDesc": "Explore the history of Delft University of Technology and the Special Collections of TU Delft Library",
-  "searchDesc": "Explore the history of Delft University of Technology and the Special Collections of TU Delft Library",
-  "exhibitionsDesc": "Explore the history of Delft University of Technology and the Special Collections of TU Delft Library",
-  "collectionsDesc": "Explore the history of Delft University of Technology and the Special Collections of TU Delft Library",
-  "publicationsDesc": "Explore the history of Delft University of Technology and the Special Collections of TU Delft Library"
+  "defaultTitle": "Academic Heritage, History and Art",
+  "defaultDesc": "Explore the history of Delft University of Technology and the Special Collections of TU Delft Library"
 }

--- a/apps/static-site/translations/en.json
+++ b/apps/static-site/translations/en.json
@@ -24,6 +24,7 @@
   "Contact and accessibility": "Contact and accessibility",
   "Article": "Article",
   "Table of contents": "Table of contents",
+  "Summary": "Summary",
   "defaultTitle": "Academic Heritage, History and Art",
   "defaultDesc": "Explore the history of Delft University of Technology and the Special Collections of TU Delft Library"
 }

--- a/apps/static-site/translations/nl.json
+++ b/apps/static-site/translations/nl.json
@@ -25,7 +25,6 @@
   "Article": "Artikel",
   "Table of contents": "Inhoudsopgave",
   "Summary": "Summier",
-  "TU Delft Academic Heritage": "TU Delft Academisch Erfgoed",
   "defaultTitle": "Academisch Erfgoed, Geschiedenis en Kunst",
   "defaultDesc": "Verken de geschiedenis van de TU Delft en de bijzondere collecties van de TU Delft Library"
 }

--- a/apps/static-site/translations/nl.json
+++ b/apps/static-site/translations/nl.json
@@ -24,11 +24,6 @@
   "Contact and accessibility": "Contact en bereikbaarheid",
   "Article": "Artikel",
   "Table of contents": "Inhoudsopgave",
-  "homeTitle": "Academisch Erfgoed, Geschiedenis en Kunst",
-  "homeDesc": "Verken de geschiedenis van de TU Delft en de bijzondere collecties van de TU Delft Library",
-  "aboutDesc": "Verken de geschiedenis van de TU Delft en de bijzondere collecties van de TU Delft Library",
-  "searchDesc": "Verken de geschiedenis van de TU Delft en de bijzondere collecties van de TU Delft Library",
-  "exhibitionsDesc": "Verken de geschiedenis van de TU Delft en de bijzondere collecties van de TU Delft Library",
-  "collectionsDesc": "Verken de geschiedenis van de TU Delft en de bijzondere collecties van de TU Delft Library",
-  "publicationsDesc": "Verken de geschiedenis van de TU Delft en de bijzondere collecties van de TU Delft Library"
+  "defaultTitle": "Academisch Erfgoed, Geschiedenis en Kunst",
+  "defaultDesc": "Verken de geschiedenis van de TU Delft en de bijzondere collecties van de TU Delft Library"
 }

--- a/apps/static-site/translations/nl.json
+++ b/apps/static-site/translations/nl.json
@@ -24,6 +24,7 @@
   "Contact and accessibility": "Contact en bereikbaarheid",
   "Article": "Artikel",
   "Table of contents": "Inhoudsopgave",
+  "Summary": "Summier",
   "defaultTitle": "Academisch Erfgoed, Geschiedenis en Kunst",
   "defaultDesc": "Verken de geschiedenis van de TU Delft en de bijzondere collecties van de TU Delft Library"
 }

--- a/apps/static-site/translations/nl.json
+++ b/apps/static-site/translations/nl.json
@@ -25,6 +25,7 @@
   "Article": "Artikel",
   "Table of contents": "Inhoudsopgave",
   "Summary": "Summier",
+  "TU Delft Academic Heritage": "TU Delft Academisch Erfgoed",
   "defaultTitle": "Academisch Erfgoed, Geschiedenis en Kunst",
   "defaultDesc": "Verken de geschiedenis van de TU Delft en de bijzondere collecties van de TU Delft Library"
 }


### PR DESCRIPTION
This PR is based on the branch for #32 so should be merged first.

Provides a consistent mechanism for customising metadata on each site page.
As we know, the Exhibition, Collection, Object detail pages will get the metadata from the meta.json file, which has been populated from the Manifest. And the Publication detail page and the About page use an mdx file.

This PR makes the rest of the pages consistent with that mechanism for supplying metadata. It adds MDX files with `title`, `description`, `image` for:
- Home,  About, Search
- Exhibitions, Collections, Publications listing pages

`title` is required

If `description` or `image` is not supplied in these files, it will use the defaults. Default description is in the lang file, and the default image is the image provided in #32 

Here are screenshots using a custom `description` and `image`. Custom values were tested locally but not pushed, followed by the initial use case: using default `description` and `image` as fallback.

Note the contents of the social share preview in each case.

CUSTOM EXAMPLES:

custom mdx code (used to test but not committed)
<img width="783" alt="custom mdx src" src="https://github.com/user-attachments/assets/639d4b95-4e3d-4fa2-8dc2-0a1905061250" />

Home custom example
<img width="717" alt="Home custom" src="https://github.com/user-attachments/assets/9d36610f-eca5-4060-b120-4f030d580063" />

Search custom example
<img width="610" alt="Search custom" src="https://github.com/user-attachments/assets/1bf25e82-a589-41b5-b313-9fdf71672a3d" />

Exhibitions custom example
<img width="610" alt="Exhibitions custom" src="https://github.com/user-attachments/assets/79b46408-dd44-4b9e-9f4d-4b7f77308b74" />

USING DEFAULTS:
Home default
<img width="598" alt="Home default" src="https://github.com/user-attachments/assets/3f682e31-6827-4d73-acbc-1ef095362099" />

About default
<img width="616" alt="About" src="https://github.com/user-attachments/assets/9f496216-7876-4e74-817e-24b85610d788" />

Search default
<img width="603" alt="Search default" src="https://github.com/user-attachments/assets/c6e18e4c-f940-480d-99f8-0583f6d7ded3" />

Exhibitions default
<img width="615" alt="Exhibitions default" src="https://github.com/user-attachments/assets/b40ef952-9d8a-45ef-8667-c428d98ab70c" />


