### PR TITLE
Use the largest thumbnail size in the resource meta file.

### DIFF
--- a/apps/iiif/.iiifrc-base.yml
+++ b/apps/iiif/.iiifrc-base.yml
@@ -9,12 +9,17 @@ run:
   - extract-slug-source
   - delft-extract-labels
   - extract-part-of-collection
-  - extract-thumbnail
+  - extract-thumbnail-local
   - manifest-sqlite
   - metadata-analysis
   - site-collections
   - delft-image-source
   - typesense-manifests
+
+config:
+  extract-thumbnail-local:
+    width: 1080
+    height: 1080
 
 stores:
   collective-access:

--- a/apps/iiif/scripts/extract-thumbnail-local.js
+++ b/apps/iiif/scripts/extract-thumbnail-local.js
@@ -1,0 +1,56 @@
+import { createThumbnailHelper } from "@iiif/helpers";
+import { extract } from "iiif-hss";
+
+extract({
+  id: "extract-thumbnail-local",
+  name: "Extract Thumbnail",
+  types: ["Manifest"],
+  invalidate: async (resource, api, config) => {
+    const cache = await api.caches.value;
+    return !cache.extractThumbnail && cache.extractThumbnail !== false;
+  }},
+  async (resource, api, config) => {
+    const vault = resource.vault;
+    const helper = createThumbnailHelper(vault);
+    const thumbnail = await helper.getBestThumbnailAtSize(
+      api.resource,
+      config.width
+        ? {
+            width: config.width,
+            height: config.height || config.width,
+          }
+        : {
+            width: 256,
+            height: 256,
+          },
+      config.dereference || false
+    );
+
+    if (thumbnail?.best) {
+      return {
+        meta: { thumbnail: thumbnail.best },
+        caches: { extractThumbnail: true },
+      };
+    }
+    else {
+      const thumbnail = await helper.getBestThumbnailAtSize(
+        api.resource, {
+              width: 256,
+              height: 256,
+            },
+        config.dereference || false
+      );
+
+      if (thumbnail?.best) {
+        return {
+          meta: { thumbnail: thumbnail.best },
+          caches: { extractThumbnail: true },
+        };
+      }
+    }
+
+    return {
+      caches: { extractThumbnail: false },
+    };
+  },
+)

--- a/apps/static-site/src/iiif.ts
+++ b/apps/static-site/src/iiif.ts
@@ -24,8 +24,10 @@ export async function loadCollection(slug: string) {
 
 export async function loadCollectionMeta(slug: string) {
   const resp = await fetch(`${IIIF_URL}${slug}/meta.json`);
+
   if (resp.ok) {
-    return resp.json();
+    const json = await resp.json();
+    return json;
   }
 }
 


### PR DESCRIPTION
Made `extract-copy-local.js` which is a local copy of `extract-thumbnail.js` from `headless-static-site`.
Tweaked this to request the thumbnail closest to 1080x1080 (recommended for og:image), with a fallback of 256x256 which is what was previously used to populate the meta file.

Exhibition
```<meta property="og:image" content="https://dlc.services/thumbs/7/24/14204410-74cc-5796-04f2-a59eeaa8ab44/full/1024,/0/default.jpg"/><meta property="og:image:width" content="1024"/><meta property="og:image:height" content="563"/>```

Object
```<meta property="og:image" content="https://dlc.services/thumbs/7/18/4045ba8b-2160-40b4-9a4b-ae2235280f3d/full/1024,/0/default.jpg"/><meta property="og:image:width" content="1024"/><meta property="og:image:height" content="683"/>```

Publication
```<meta property="og:image" content="https://dlc.services/thumbs/7/21/b65dbfcc-4daf-0b7d-86fc-74a126248b03/full/full/0/default.jpg"/><meta property="og:image:width" content="1080"/>```